### PR TITLE
[Hotfix] Django Translation Needs gettext

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
         apt-utils \
         postgresql-client \
+        gettext \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add application source code to SRCDIR

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -12,6 +12,7 @@ python manage.py migrate guardian --noinput
 python manage.py migrate jet --noinput
 python manage.py migrate dashboard --noinput
 python manage.py migrate --noinput               # Apply database migrations
+django-admin compilemessages                     # Compile *.po translation files
 python manage.py collectstatic --clear --noinput # Collect static files
 
 # Prepare log files and start outputting logs to stdout


### PR DESCRIPTION
Django translation needs gettext: https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#message-files

 - [x] Add `gettext` to list of dependencies in `Dockerfile`.
 - [x] Add `django-admin compilemessages` to `entrypoint.sh`.
