### PR TITLE
[Hotfix] Language Switcher

### DIFF
--- a/gmmp/templatetags/i18n_switcher.py
+++ b/gmmp/templatetags/i18n_switcher.py
@@ -24,7 +24,7 @@ def switch_lang_code(path, language):
     # Add or substitute the new language prefix
     if parts[1] in lang_codes:
         if language == "en":
-            parts[1] = ""
+            parts.pop(1)
         else:
             parts[1] = language
     elif not language == "en":


### PR DESCRIPTION
## Description
Switching languages (from FR or ES) back to English fails due to double `//`

## Screenshots

### Before

![Peek 2020-03-06 16-59](https://user-images.githubusercontent.com/1779590/76090493-bbfb5800-5fcc-11ea-8c1a-9d3bcb967596.gif)

### After

![Peek 2020-03-06 17-00](https://user-images.githubusercontent.com/1779590/76090514-c0c00c00-5fcc-11ea-85f6-26fadb6ee5bc.gif)
