### PR TITLE
Bump django from 2.2.9 to 2.2.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2.9
+Django==2.2.11
 XlsxWriter==1.2.8
 dj-database-url==0.5.0
 dj-static==0.0.6


### PR DESCRIPTION
## Description

Security fix: upgrade Django to `v2.2.11`