### PR TITLE
[Bug] Fix Age Input Not Showing in Twitter Add Page

### DIFF
--- a/forms/admin.py
+++ b/forms/admin.py
@@ -110,7 +110,6 @@ For each online news story, you should code each journalist/reporter who wrote t
 Unnamed journalists (e.g. 'Staff reporter', 'Our correspondent')
 <br/>
 News agencies''')
-    exclude = ('age',)
 
 
 # People In The News


### PR DESCRIPTION
## Description

Age was not showing on the Twitter add page even though it was supposed to. This PR fixes that bug.

## Screenshots

![image](https://user-images.githubusercontent.com/8318974/91042278-6877d780-e609-11ea-9e0a-1cc0d75a1bad.png)

