### PR TITLE
Make Optional People Questions Required if 'yes' is Selected

### DIFF
--- a/forms/static/forms/admin/dependency_fields.js
+++ b/forms/static/forms/admin/dependency_fields.js
@@ -11,15 +11,37 @@
         }
     });
     $(document).change(function() {
+        const removeValue = function(id) {
+            $(`#${id}`).children('option:first').removeAttr('value');
+        };
+        const addValue = function(id) {
+            $(`#${id}`).children('option:first').attr('value', '');
+        };
         let newspaper_person = $('#id_newspaperperson_set-0-victim_or_survivor_1:checked').length;
         let radio_person = $('#id_radioperson_set-0-victim_or_survivor_1:checked').length;
         let tv_person = $('#id_televisionperson_set-0-victim_or_survivor_1:checked').length;
         let internent_person = $('#id_internetnewsperson_set-0-victim_or_survivor_1:checked').length;
 
         if((newspaper_person > 0) || (radio_person > 0) || (tv_person > 0) || (internent_person > 0)){
+            addValue('id_newspaperperson_set-0-victim_of');
+            addValue('id_newspaperperson_set-0-survivor_of');
+            addValue('id_radioperson_set-0-victim_of');
+            addValue('id_radioperson_set-0-survivor_of');
+            addValue('id_televisionperson_set-0-victim_of');
+            addValue('id_televisionperson_set-0-survivor_of');
+            addValue('id_internetnewsperson_set-0-victim_of');
+            addValue('id_internetnewsperson_set-0-survivor_of');
             $('.field-victim_of').hide();
             $('.field-survivor_of').hide();
         }else{
+            removeValue('id_newspaperperson_set-0-victim_of');
+            removeValue('id_newspaperperson_set-0-survivor_of');
+            removeValue('id_radioperson_set-0-victim_of');
+            removeValue('id_radioperson_set-0-survivor_of');
+            removeValue('id_televisionperson_set-0-victim_of');
+            removeValue('id_televisionperson_set-0-survivor_of');
+            removeValue('id_internetnewsperson_set-0-victim_of');
+            removeValue('id_internetnewsperson_set-0-survivor_of');
             $('.field-victim_of').show();
             $('.field-survivor_of').show();
         }


### PR DESCRIPTION
## Description

This PR ensures that optional questions are validated if yes is selected in `PEOPLE IN THE NEWS` tab.

Fixes #174639229

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
