### PR TITLE
[Fix] Docker CMD parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV PYTHONUNBUFFERED 1
 ####  We need libpq-dev in both build and final runtime image
 RUN apt-get update \
     && apt-get -y upgrade \
-    && apt-get -y install libpq-dev \
+    && apt-get -y install gettext libpq-dev \
     && apt-get clean
 
 ###############################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ RUN chmod +x /entrypoint.sh \
 
 ### Run app
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/cmd.sh"]
+CMD ["/cmd.sh", "gmmp.wsgi:application"]

--- a/contrib/docker/cmd.sh
+++ b/contrib/docker/cmd.sh
@@ -21,5 +21,4 @@ exec gunicorn \
   --log-file=/app/logs/gunicorn.log \
   --access-logfile=/app/logs/access.log \
   --name=gmmp \
-  gmmp.wsgi:application
   "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,8 @@ services:
       - DJANGO_DEBUG=${DJANGO_DEBUG:-True} # For testing deploys
       - GMMP_EMAIL_HOST_PASSWORD=${GMMP_EMAIL_HOST_PASSWORD}
       - OAUTHLIB_RELAX_TOKEN_SCOPE=1 # https://stackoverflow.com/a/51643134
-    command:
-      [
-        "./contrib/docker/cmd.sh",
+    command: [
         "--log-level=debug",
-        "--name=gmmp",
         "--reload",
         "gmmp.wsgi:application",
       ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - GMMP_EMAIL_HOST_PASSWORD=${GMMP_EMAIL_HOST_PASSWORD}
       - OAUTHLIB_RELAX_TOKEN_SCOPE=1 # https://stackoverflow.com/a/51643134
     command: [
+        "/cmd.sh",
         "--log-level=debug",
         "--reload",
         "gmmp.wsgi:application",


### PR DESCRIPTION
## Description

 - [x] Allow customization of `gunicorn` startup parameters to cater for production and development environments,
 - [x] Fix `docker-compose` startup error, and
 - [x] Fix `CommandError: Can't find msguniq. Make sure you have GNU gettext tools 0.15 or newer installed`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![Screenshot from 2020-09-10 16-10-49](https://user-images.githubusercontent.com/1779590/92733557-72773580-f380-11ea-8338-8427d24722e7.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
