### PR TITLE
Fix reports generation

### DIFF
--- a/forms/modelutils.py
+++ b/forms/modelutils.py
@@ -342,7 +342,8 @@ class Person(models.Model):
         """ Return the name of the sheet relation field
         """
         for fld in cls._meta.fields:
-            if hasattr(fld, 'related') and fld.related and issubclass(fld.related.parent_model, SheetModel):
+            # related field was removed https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-1-10
+            if fld.is_relation and issubclass(fld.related_model, SheetModel):
                 return fld.name.split(':')[-1]
 
 
@@ -375,7 +376,8 @@ class Journalist(models.Model):
         """ Return the name of the sheet relation field
         """
         for fld in cls._meta.fields:
-            if hasattr(fld, 'related') and fld.related and issubclass(fld.related.parent_model, SheetModel):
+            # related field was removed https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-1-10
+            if fld.is_relation and issubclass(fld.related_model, SheetModel):
                 return fld.name.split(':')[-1]
 
 class BroadcastJournalist(Journalist):

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -149,7 +149,7 @@ class XLSXReportBuilder:
         """
         Generate an Excel spreadsheet and return it as a string.
         """
-        output = io.StringIO()
+        output = io.BytesIO()
         workbook = xlsxwriter.Workbook(output)
 
         # setup formats


### PR DESCRIPTION
## Description

Fixes the report generation Issue.
- The report generator was not working since it was initially created to work on python2. After the upgrade to `python3`, how `ZipFile` module worked was updated and this PR addresses that.
- On upgrade of **Django** version, the `related field` was removed https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-1-10
This PR updates how we get the related field.

**Note**:
The Global report generation does not work and I think It didn't work in the previous version too. Reason being the `GlobalForm` class is empty.

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
