### PR TITLE
Ensures validation is only added if the first checkbox is checked.

### DIFF
--- a/forms/static/forms/admin/dependent_fields.js
+++ b/forms/static/forms/admin/dependent_fields.js
@@ -16,7 +16,7 @@
          * **NOT** selected, implying **YES** is selected.
          */
         var toggle_validation = function toggle_validation(person_set, el) {
-            if (el.id === 'id_' + person_set + '-victim_or_survivor_2') {
+            if (el.id === 'id_' + person_set + '-victim_or_survivor_1') {
                 var add_validation$ = function(id) {
                     // Set --- since it's an invalid value and thus will receive
                     // validation error if user doesn't select another value
@@ -25,7 +25,7 @@
                 var remove_validation$ = function(id) {
                     $(id).children('option:first').attr('value', '');
                 };
-                if (!$(el).prop('checked')) {
+                if ($(el).prop('checked')) {
                     add_validation$('#id_' + person_set + '-victim_of');
                     add_validation$('#id_' + person_set + '-survivor_of');
                 } else {
@@ -39,11 +39,11 @@
          */
         var toggle_person_set_victim_or_survivor_questions =
             function toggle_person_set_victim_or_survivor_questions(person_set, el) {
-                if (el.id === 'id_' + person_set + '-victim_or_survivor_2') {
+                if (el.id === 'id_' + person_set + '-victim_or_survivor_1') {
                     var $person_set = $('#' + person_set);
                     var $person_set_victim_question = $person_set.find('.field-victim_of');
                     var $person_set_survivor_question = $person_set.find('.field-survivor_of');
-                    if ($(el).prop('checked')) { 
+                    if (!$(el).prop('checked')) { 
                         $person_set_victim_question.hide();
                         $person_set_survivor_question.hide();
                     } else {
@@ -53,25 +53,25 @@
                 }
             };
         var newspaper_person_set = 'newspaperperson_set';
-        var $newspaper_person_victim_or_survivor = $("input[id^='id_" + newspaper_person_set + "-'][id$='-victim_or_survivor_2']");
+        var $newspaper_person_victim_or_survivor = $("input[id^='id_" + newspaper_person_set + "-'][id$='-victim_or_survivor_1']");
         $newspaper_person_victim_or_survivor.each(function (index) {
             toggle_validation(newspaper_person_set + '-' + index, this);
             toggle_person_set_victim_or_survivor_questions(newspaper_person_set + '-' + index, this);
         });
         var radio_person_set = 'radioperson_set';
-        var $radio_person_victim_or_survivor = $("input[id^='id_" + radio_person_set +  "-'][id$='-victim_or_survivor_2']");
+        var $radio_person_victim_or_survivor = $("input[id^='id_" + radio_person_set +  "-'][id$='-victim_or_survivor_1']");
         $radio_person_victim_or_survivor.each(function (index) {
             toggle_validation(radio_person_set + '-' + index, this);
             toggle_person_set_victim_or_survivor_questions(radio_person_set + '-' + index, this);
         });
         var tv_person_set = 'televisionperson_set';
-        var $tv_person_victim_or_survivor = $("input[id^='id_" + tv_person_set + "-'][id$='-victim_or_survivor_2']");
+        var $tv_person_victim_or_survivor = $("input[id^='id_" + tv_person_set + "-'][id$='-victim_or_survivor_1']");
         $tv_person_victim_or_survivor.each(function (index) {
             toggle_validation(tv_person_set + '-' + index, this);
             toggle_person_set_victim_or_survivor_questions(tv_person_set + '-' + index, this);
         });
         var internet_person_set = 'internetnewsperson_set';
-        var $internet_person_victim_or_survivor = $("input[id^='id_" + internet_person_set + "-'][id$='-victim_or_survivor_2']");
+        var $internet_person_victim_or_survivor = $("input[id^='id_" + internet_person_set + "-'][id$='-victim_or_survivor_1']");
         $internet_person_victim_or_survivor.each(function (index) {
             toggle_validation(internet_person_set + '-' + index, this);
             toggle_person_set_victim_or_survivor_questions(internet_person_set + '-' + index, this);

--- a/forms/static/forms/admin/dependent_fields.js
+++ b/forms/static/forms/admin/dependent_fields.js
@@ -12,8 +12,8 @@
         $('.field-victim_or_survivor').show();
 
         /**
-         * Toggles using the `No` answer i.e. add validation if `No` is
-         * **NOT** selected, implying **YES** is selected.
+         * Toggles using the `Yes` answer i.e. add validation if `Yes` is
+         * selected, If `No` is selected or nothing is selected at all, we remove validation.
          */
         var toggle_validation = function toggle_validation(person_set, el) {
             if (el.id === 'id_' + person_set + '-victim_or_survivor_1') {
@@ -35,7 +35,7 @@
             }
         };
         /**
-         * Toggles using the `No` answer i.e. hide if `No` is selected.
+         * Toggles using the `Yes` answer i.e. show if `Yes` is selected.
          */
         var toggle_person_set_victim_or_survivor_questions =
             function toggle_person_set_victim_or_survivor_questions(person_set, el) {


### PR DESCRIPTION
## Description
Validation was being added only if the second checkbox wasn't selected which would always be the case when non of the checkboxes is selected.
Fixes # (issue)
Ensures validation is only added if the first checkbox is checked.
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
