### PR TITLE
Ensure all persons are marked as deleted

### DIFF
--- a/forms/admin.py
+++ b/forms/admin.py
@@ -49,9 +49,37 @@ class PermsAdmin(GuardedModelAdmin):
     
     def delete_model(self, request, obj):
         obj.deleted = True
-        # Mark all Newspaper Person and Journalists as deleted too
-        obj.newspaperperson_set.update(deleted=True)
-        obj.newspaperjournalist_set.update(deleted=True)
+        # Mark all Persons and Journalists as deleted too
+        if hasattr(obj, 'newspaperperson_set'):
+            obj.newspaperperson_set.update(deleted=True)
+        
+        if hasattr(obj, 'newspaperjournalist_set'):
+            obj.newspaperjournalist_set.update(deleted=True)
+
+        if hasattr(obj, 'radioperson_set'):
+            obj.radioperson_set.update(deleted=True)
+        
+        if hasattr(obj, 'radiojournalist_set'):
+            obj.radiojournalist_set.update(deleted=True)
+        
+        if hasattr(obj, 'televisionperson_set'):
+            obj.televisionperson_set.update(deleted=True)
+        
+        if hasattr(obj, 'televisionjournalist_set'):
+            obj.televisionjournalist_set.update(deleted=True)
+        
+        if hasattr(obj, 'internentperson_set'):
+            obj.internentperson_set.update(deleted=True)
+        
+        if hasattr(obj, 'internentjournalist_set'):
+            obj.internentjournalist_set.update(deleted=True)
+        
+        if hasattr(obj, 'twitterperson_set'):
+            obj.twitterperson_set.update(deleted=True)
+        
+        if hasattr(obj, 'twitterjournalist_set'):
+            obj.twitterjournalist_set.update(deleted=True)
+
         obj.save()
         return
 


### PR DESCRIPTION
## Description

Previously only newspaper person and journalists were being marked as deleted. For other sheets, e.g Radio, when an attempt to delete is made an exception was being raised.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
