### PR TITLE
Add historical data for sheets that didn't have historical data in 2015

### DIFF
--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -1281,6 +1281,8 @@ class XLSXReportBuilder:
                 secondary_counts[region_name] = counts
 
             self.tabulate_secondary_cols(ws, secondary_counts, self.male_female, MAJOR_TOPICS, row_perc=False, show_N=True)
+        c = ws.dim_colmax + 2
+        self.tabulate_historical(ws, '30', self.male_female, MAJOR_TOPICS, write_row_headings=True, major_cols=self.regions, c=c, show_N_and_P=True)
 
     def ws_31(self, ws):
         """

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -1221,6 +1221,8 @@ class XLSXReportBuilder:
                 secondary_counts[region_name] = counts
 
             self.tabulate_secondary_cols(ws, secondary_counts, self.male_female, SCOPE, row_perc=False, show_N=True)
+        c = ws.dim_colmax + 2
+        self.tabulate_historical(ws, '29', self.male_female, SCOPE, write_row_headings=True, c=c, major_cols=self.regions, show_N_and_P=True)
 
     def ws_30(self, ws):
         """

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -746,6 +746,7 @@ class XLSXReportBuilder:
                     counts.update({(r['space'], TOPIC_GROUPS[r['topic']]): r['n']})
 
         self.tabulate(ws, counts, SPACE, MAJOR_TOPICS, row_perc=False)
+        self.tabulate_historical(ws, '10', SPACE, MAJOR_TOPICS)
 
     def ws_11(self, ws):
         """

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -4608,7 +4608,13 @@ class XLSXReportBuilder:
                         value = data[canon(col_heading)].get(canon(row_heading))
 
                         if value is None:
-                            value = ['n/a'] * values_per_col
+                            # check if it's due to having % and N
+                            p = data.get(canon(col_heading), {}).get('%', {})
+                            n = data.get(canon(col_heading), {}).get('n', {})
+                            if (p or n):
+                                value = [p.get(canon(row_heading), "n/a"), n.get(canon(row_heading), "n/a")]
+                            else:
+                                value = ['n/a'] * values_per_col
                         elif not isinstance(value, list):
                             value = [value]
 

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -820,6 +820,8 @@ class XLSXReportBuilder:
             secondary_counts[gender] = counts
 
         self.tabulate_secondary_cols(ws, secondary_counts, YESNO, MAJOR_TOPICS, row_perc=True)
+        c = ws.dim_colmax + 2
+        self.tabulate_historical(ws, '13', [*YESNO], MAJOR_TOPICS, write_row_headings=True, major_cols=self.male_female)
 
     def ws_14(self, ws):
         """

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -1339,6 +1339,8 @@ class XLSXReportBuilder:
             secondary_counts[media_type] = counts
 
         self.tabulate_secondary_cols(ws, secondary_counts, self.male_female, [y for x in TOPICS for y in x[1]], row_perc=False, show_N=True)
+        c = ws.dim_colmax + 2
+        self.tabulate_historical(ws, '32', self.male_female, [y for x in TOPICS for y in x[1]], write_row_headings=True, c=c, show_N_and_P=True, major_cols=TM_MEDIA_TYPES)
 
     def ws_34(self, ws):
         """

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -792,6 +792,8 @@ class XLSXReportBuilder:
             secondary_counts[region_name] = counts
 
         self.tabulate_secondary_cols(ws, secondary_counts, YESNO, MAJOR_TOPICS, row_perc=True)
+        c = ws.dim_colmax + 2
+        self.tabulate_historical(ws, '12', [*YESNO], MAJOR_TOPICS, c=c, r=7, major_cols=self.regions)
 
     def ws_13(self, ws):
         """

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -767,6 +767,7 @@ class XLSXReportBuilder:
                     counts.update({(r['equality_rights'], TOPIC_GROUPS[r['topic']]): r['n']})
 
         self.tabulate(ws, counts, YESNO, MAJOR_TOPICS, row_perc=True)
+        self.tabulate_historical(ws, '11', [*YESNO], MAJOR_TOPICS, write_row_headings=False)
 
     def ws_12(self, ws):
         """

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -1451,6 +1451,7 @@ class XLSXReportBuilder:
                     counts.update({(r['about_women'], TOPIC_GROUPS[r['topic']]): r['n']})
 
         self.tabulate(ws, counts, YESNO, MAJOR_TOPICS, row_perc=True)
+        self.tabulate_historical(ws, '38', YESNO, MAJOR_TOPICS, write_row_headings=False)
 
     def ws_39(self, ws):
         """


### PR DESCRIPTION
## Description

Adds historical data for sheets that didn't have historical data in 2015

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
![Screenshot 2021-02-24 at 13 13 59](https://user-images.githubusercontent.com/13068580/108985522-34599e00-76a2-11eb-82fb-54814d2a4e57.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
