### PR TITLE
[Fix] Show ALPHA3  in raw sheets of the report

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,10 @@ services:
       - PGDATABASE=gmmp
       - PGUSER=gmmp
       - PGPASSWORD=gmmp
-      - PYTHONDONTWRITEBYTECODE="True"
+      - PYTHONDONTWRITEBYTECODE=True
       - DJANGO_DEBUG=${DJANGO_DEBUG:-True} # For testing deploys
       - GMMP_EMAIL_HOST_PASSWORD=${GMMP_EMAIL_HOST_PASSWORD}
+      - GMMP_REPORTS_HISTORICAL_YEAR=${GMMP_REPORTS_HISTORICAL_YEAR:-2010}
       - OAUTHLIB_RELAX_TOKEN_SCOPE=1 # https://stackoverflow.com/a/51643134
     command: [
         "/cmd.sh",

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -10,6 +10,7 @@ from django.db import connection
 from django.db.models import Count, FieldDoesNotExist
 
 # 3rd Party
+from django_countries import countries
 import xlsxwriter
 
 # Project
@@ -348,7 +349,7 @@ class XLSXReportBuilder:
             for fld in obj._meta.fields:
                 attr = fld.attname
                 if attr == 'country':
-                    v = obj.country.code
+                    v = countries.alpha3(obj.country.code)
 
                 elif attr == 'country_region_id':
                     v = country_regions[obj.country_region_id]
@@ -376,7 +377,11 @@ class XLSXReportBuilder:
                 # write the looked-up value
                 actual_v = v
                 if attr in lookups:
-                    v = lookups[attr].get(v, v)
+                    choices = lookups[attr]
+                    if attr == 'country':
+                        v = choices.get(obj.country.code, v)
+                    else:
+                        v = choices.get(v, v)
                     if v is not None:
                         v = str(v)
                     ws.write(r + 1, c, v)


### PR DESCRIPTION
## Description

Use `alpha3` (ISO 3166-1 three character country code) instead of `code` (ISO 3166-1 two character country code) in the `country_code` column of the raw sheets of the report.

### Others

Make `GMMP_REPORTS_HISTORICAL_YEAR` configurable via `.env` file for easier local testing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![Screenshot from 2021-02-24 20-47-42](https://user-images.githubusercontent.com/1779590/109045802-119ca900-76e5-11eb-8524-d9ec1d13fdb0.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
