### PR TITLE
[Feature] Covid stories: gender stereotypes, by major topic

### DIFF
--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -3080,7 +3080,24 @@ class XLSXReportBuilder:
         self.tabulate(ws, counts_list[0], self.male_female, self.countries, row_perc=True, show_N=True)
 
     def ws_102(self, ws):
-        return
+        """
+        Cols: Gender stereotypes
+        Rows: Major topic, covid stories only
+        """
+        counts = Counter()
+        for media_type, model in sheet_models.items():
+            rows = (
+                model.objects.values("stereotypes", "topic")
+                .filter(covid19=1, country__in=self.country_list)
+                .annotate(n=Count("id"))
+            )
+
+            rows = self.apply_weights(rows, model._meta.db_table, media_type)
+
+            for r in rows:
+                counts.update({(r["stereotypes"], TOPIC_GROUPS[r["topic"]]): r["n"]})
+
+        self.tabulate(ws, counts, AGREE_DISAGREE, MAJOR_TOPICS, row_perc=True)
     
     def ws_103(self, ws):
         return

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -3044,14 +3044,21 @@ class XLSXReportBuilder:
         return
     
     def ws_100(self, ws):
-        counts_list = []
+        """
+        Cols: Medium 
+        Rows: Major topic
+        """
         secondary_counts = OrderedDict()
-        for media_types, models in SHEET_MEDIA_GROUPS:
+        for _, models in SHEET_MEDIA_GROUPS:
             for media_type, model in models.items():
                 counts = Counter()
                 rows = model.objects\
-                        .values('covid19', 'topic')\
+                        .values('covid19', 'topic') \
+                        .filter(country__in=self.country_list) \
                         .annotate(n=Count('id'))
+                        
+                rows = self.apply_weights(rows, model._meta.db_table, media_type)
+            
                 for r in rows:
                     covid19 = 'Y' if r['covid19'] == 1 else 'N'
                     counts.update({(covid19, TOPIC_GROUPS[r['topic']]): r['n']})

--- a/reports/report_details.py
+++ b/reports/report_details.py
@@ -1541,8 +1541,8 @@ WS_INFO = {
         '2015': {
             'name': '102',
             'title': 'Covid stories: gender stereotypes, by major topic',
-            'desc': 'Covid stories: gender stereotypes, by major topic',
-            'reports': ['region', 'country'],
+            'desc': '',
+            'reports': ['global', 'region', 'country'],
         },
     },
     'ws_103': {


### PR DESCRIPTION
## Description

This PR implements sheet `102`: **Covid stories: gender stereotypes, by major topic**

It also fixes sheet 100 by:

 - [x] filter using `country_list`, and
 - [x] apply weights.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Screenshot from 2021-03-02 17-06-10](https://user-images.githubusercontent.com/1779590/109660292-baca2000-7b79-11eb-9391-3516aa53e444.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
