### PR TITLE
[Fix] Sheet order

### DIFF
--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -100,6 +100,25 @@ def get_sheet_model_name_field(media_type):
     elif media_type == "Radio":
         return "channel"
 
+def sheet_name_to_int(sheet):
+    """
+    Helper function to convert sheet name to it's numerical equivalent taking
+    into account difference
+    e.g. returns 10 for ws_10
+    """
+    stripped_sheet = sheet.strip("wsr_")
+    try:
+        num = int(stripped_sheet)
+    except ValueError:
+        num = 0
+    if sheet.startswith("ws_sr"):
+        return 400 + num
+    
+    if sheet.startswith("ws_s"):
+        return 200 + num
+    
+    return num
+
 
 class XLSXReportBuilder:
     def __init__(self, form):
@@ -181,8 +200,8 @@ class XLSXReportBuilder:
             sheet_info = WS_INFO[sheet].get(self.historical_year)
             if sheet_info and ("reports" in sheet_info and self.report_type in sheet_info["reports"]):
                 report_type_sheets.append(sheet)
-                
-        sheets = sorted(report_type_sheets)
+
+        sheets = sorted(report_type_sheets, key=sheet_name_to_int)
 
         self.write_key_sheet(workbook, sheets)
 

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -100,17 +100,22 @@ def get_sheet_model_name_field(media_type):
     elif media_type == "Radio":
         return "channel"
 
-def sheet_name_to_int(sheet):
+def sheet_name_to_num(sheet):
     """
     Helper function to convert sheet name to it's numerical equivalent taking
-    into account difference
-    e.g. returns 10 for ws_10
+    into account different type of sheets.
+    e.g. returns 10 for ws_10, 10.1 for ws_10b, and 202 for ws_s02.
+    Sheets are banded: 0 - 199 normal sheets, 200 - 399 s sheets, and 400+ for
+    sr sheets.
     """
-    stripped_sheet = sheet.strip("wsr_")
+    stripped_sheet = sheet.strip("wsrb_")
     try:
-        num = int(stripped_sheet)
+        num = int(stripped_sheet, 10)
     except ValueError:
-        num = 0
+       num = 0
+
+    if sheet.endswith("b"):
+        num += 0.1
     if sheet.startswith("ws_sr"):
         return 400 + num
     
@@ -201,7 +206,7 @@ class XLSXReportBuilder:
             if sheet_info and ("reports" in sheet_info and self.report_type in sheet_info["reports"]):
                 report_type_sheets.append(sheet)
 
-        sheets = sorted(report_type_sheets, key=sheet_name_to_int)
+        sheets = sorted(report_type_sheets, key=sheet_name_to_num)
 
         self.write_key_sheet(workbook, sheets)
 


### PR DESCRIPTION
## Description

Adds natural ordering of sheets in the final Excel file rather than the current string-based i.e. `"100"` is sorted before `"2"`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![Peek 2021-03-02 17-41](https://user-images.githubusercontent.com/1779590/109665002-cec45080-7b7e-11eb-9a1b-dcbfe63a8653.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

