### PR TITLE
[Feature] Covid stories: highlight gender inequalities, by major topic

### DIFF
--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -3071,7 +3071,7 @@ class XLSXReportBuilder:
                 .values("topic", model.journalist_field_name() + "__sex") \
                 .filter(covid19=1,
                         **{model.journalist_field_name() + "__sex__in": self.male_female_ids},
-                        country__in=self.country_list)\
+                        country__in=self.country_list) \
                 .annotate(n=Count("id"))
 
             rows = self.apply_weights(rows, model._meta.db_table, media_type)

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -3061,24 +3061,25 @@ class XLSXReportBuilder:
         self.tabulate_secondary_cols(ws, secondary_counts, YESNO, MAJOR_TOPICS, row_perc=True)
 
     def ws_101(self, ws):
-        counts_list = []
-        for _, model in sheet_models.items():
-            counts = Counter()
-            sex = model.journalist_field_name() + '__sex'
-
+        """
+        Cols: Reporters by sex
+        Rows: Major topic, covid stories only
+        """
+        counts = Counter()
+        for media_type, model in sheet_models.items():
             rows = model.objects \
-                .values('covid19', 'topic', sex, 'country') \
-                .filter(**{model.journalist_field_name() + '__sex__in': self.male_female_ids}) \
-                .filter(country__in=self.country_list)\
-                .annotate(n=Count('id'))
+                .values("topic", model.journalist_field_name() + "__sex") \
+                .filter(covid19=1,
+                        **{model.journalist_field_name() + "__sex__in": self.male_female_ids},
+                        country__in=self.country_list)\
+                .annotate(n=Count("id"))
 
-            rows = [row for row in rows if row['covid19'] == 1]
+            rows = self.apply_weights(rows, model._meta.db_table, media_type)
 
-            for row in rows:
-                counts.update({(row[sex], self.recode_country(row['country'])): row['n']})
-            counts_list.append(counts)
+            for r in rows:
+                counts.update({(r["sex"], TOPIC_GROUPS[r["topic"]]): r["n"]})
 
-        self.tabulate(ws, counts_list[0], self.male_female, self.countries, row_perc=True, show_N=True)
+        self.tabulate(ws, counts, GENDER, MAJOR_TOPICS, row_perc=True, show_N=True)
 
     def ws_102(self, ws):
         return
@@ -3090,11 +3091,11 @@ class XLSXReportBuilder:
         """
         counts = Counter()
         for media_type, model in sheet_models.items():
-            if 'equality_rights' in [field_name.name for field_name in model._meta.get_fields()]:
+            if "equality_rights" in [field_name.name for field_name in model._meta.get_fields()]:
                 rows = model.objects\
-                        .values('equality_rights', 'topic') \
+                        .values("equality_rights", "topic") \
                         .filter(covid19=1, country__in=self.country_list) \
-                        .annotate(n=Count('id'))
+                        .annotate(n=Count("id"))
 
                 rows = self.apply_weights(rows, model._meta.db_table, media_type)
 

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -1,7 +1,6 @@
 # Python
 import io
 from collections import Counter, OrderedDict
-from itertools import count
 import logging
 import datetime
 

--- a/reports/report_details.py
+++ b/reports/report_details.py
@@ -1549,8 +1549,8 @@ WS_INFO = {
         '2015': {
             'name': '103',
             'title': 'Covid stories: highlight gender inequalities, by major topic',
-            'desc': 'Covid stories: highlight gender inequalities, by major topic',
-            'reports': ['region', 'country'],
+            'desc': '',
+            'reports': ['global', 'region', 'country'],
         },
     },
     'ws_104': {


### PR DESCRIPTION
## Description

Implements sheet `103`: **Covid stories: highlight gender inequalities, by major topic**.

The PR also fixes sheet `101`

 - [x] Switches rows to major topics instead for countries,
 - [x] Ensure weights are applied. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

### Sheet 103

![Screenshot from 2021-03-03 09-43-13](https://user-images.githubusercontent.com/1779590/109764709-efcf8480-7c04-11eb-8ecb-e24f72f98313.png)

### Sheet 101

![101](https://user-images.githubusercontent.com/1779590/109764590-cf072f00-7c04-11eb-87a5-18ef119a1525.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
