### PR TITLE
[Feature] Special questions queries

### DIFF
--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -3,7 +3,6 @@ import io
 from collections import Counter, OrderedDict
 import logging
 import datetime
-from typing import Sequence
 
 # Django
 from django.conf import settings

--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -3,6 +3,7 @@ import io
 from collections import Counter, OrderedDict
 import logging
 import datetime
+from typing import Sequence
 
 # Django
 from django.conf import settings
@@ -3228,19 +3229,139 @@ class XLSXReportBuilder:
         return
     
     def ws_107(self, ws):
-        return
-    
+        """
+        Cols: Medium 
+        Rows: SQ 1,2,3, Major topic
+        """
+        r = 6
+        self.write_col_headings(ws, MEDIA_TYPES)
+
+        for sq_field, sq in SPECIAL_QUESTIONS.items():
+            counts = Counter()
+            for media_type, model in person_models.items():
+                sheet_name = model.sheet_name()
+                rows = model.objects \
+                        .values(sq_field, f"{sheet_name}__topic") \
+                        .filter(**{f"{sheet_name}__country__in": self.country_list}) \
+                        .exclude(**{sq_field: ""}) \
+                        .annotate(n=Count("id"))
+
+                rows= self.apply_weights(rows, model.sheet_db_table(), media_type)
+
+                media_id = [id for id, name in MEDIA_TYPES if name == media_type][0]
+                counts.update({(media_id, TOPIC_GROUPS[r['topic']]): r['n'] for r in rows})
+
+            self.write_primary_row_heading(ws, sq, r=r)
+            self.tabulate(ws, counts, MEDIA_TYPES, MAJOR_TOPICS, row_perc=True, write_col_headings=False, r=r)
+            r += len(MAJOR_TOPICS)
+
     def ws_108(self, ws):
-        return
-    
+        """
+        Cols: People in the news, by sex 
+        Rows: SQ 1,2,3, Major topic
+        """
+        r = 6
+        self.write_col_headings(ws, GENDER)
+
+        gender_ids = [x[0] for x in GENDER]
+        for sq_field, sq in SPECIAL_QUESTIONS.items():
+            counts = Counter()
+            for media_type, model in person_models.items():
+                sheet_name = model.sheet_name()
+                rows = model.objects \
+                        .values(sq_field, "sex", f"{sheet_name}__topic") \
+                        .filter(**{f"{sheet_name}__country__in": self.country_list}) \
+                        .exclude(**{sq_field: ""}) \
+                        .filter(sex__in=gender_ids) \
+                        .annotate(n=Count("id"))
+
+                rows= self.apply_weights(rows, model.sheet_db_table(), media_type)
+
+                counts.update({(r["sex"], TOPIC_GROUPS[r['topic']]): r['n'] for r in rows})
+
+            self.write_primary_row_heading(ws, sq, r=r)
+            self.tabulate(ws, counts, GENDER, MAJOR_TOPICS, row_perc=True, write_col_headings=False, r=r)
+            r += len(MAJOR_TOPICS)
+
     def ws_109(self, ws):
-        return
-    
+        """
+        Cols: Reporters by sex
+        Rows: SQ 1,2,3, Major topic
+        """
+        r = 6
+        self.write_col_headings(ws, GENDER)
+
+        gender_ids = [x[0] for x in GENDER]
+        for sq_field, sq in SPECIAL_QUESTIONS.items():
+            counts = Counter()
+            for media_type, model in person_models.items():
+                sheet_name = model.sheet_name()
+                journalist_field_name = model._meta.get_field(model.sheet_name()).remote_field.model.journalist_field_name()
+                rows = model.objects \
+                        .values(sq_field, f"{sheet_name}__{journalist_field_name}__sex", f"{sheet_name}__topic") \
+                        .filter(**{f"{sheet_name}__country__in": self.country_list}) \
+                        .exclude(**{sq_field: ""}) \
+                        .filter(**{f"{sheet_name}__{journalist_field_name}__sex__in": gender_ids}) \
+                        .annotate(n=Count("id"))
+                        
+                rows= self.apply_weights(rows, model.sheet_db_table(), media_type)
+                counts.update({(r["sex"], TOPIC_GROUPS[r['topic']]): r['n'] for r in rows})
+
+            self.write_primary_row_heading(ws, sq, r=r)
+            self.tabulate(ws, counts, GENDER, MAJOR_TOPICS, row_perc=True, write_col_headings=False, r=r)
+            r += len(MAJOR_TOPICS)
+
     def ws_110(self, ws):
-        return
+        """
+        Cols: Rights 
+        Rows: SQ 1,2,3, Major topic
+        """
+        r = 6
+        self.write_col_headings(ws, YESNO)
+
+        for sq_field, sq in SPECIAL_QUESTIONS.items():
+            counts = Counter()
+            for media_type, model in person_models.items():
+                sheet_name = model.sheet_name()
+                rows = model.objects \
+                        .values(sq_field, f"{sheet_name}__equality_rights", f"{sheet_name}__topic") \
+                        .filter(**{f"{sheet_name}__country__in": self.country_list}) \
+                        .exclude(**{sq_field: ""}) \
+                        .annotate(n=Count("id"))
+
+                rows= self.apply_weights(rows, model.sheet_db_table(), media_type)
+
+                counts.update({(r["equality_rights"], TOPIC_GROUPS[r['topic']]): r['n'] for r in rows})
+
+            self.write_primary_row_heading(ws, sq, r=r)
+            self.tabulate(ws, counts, YESNO, MAJOR_TOPICS, row_perc=True, write_col_headings=False, r=r)
+            r += len(MAJOR_TOPICS)
 
     def ws_111(self, ws):
-        return
+        """
+        Cols: Gender stereotypes
+        Rows: SQ 1,2,3, Major topic
+        """
+        r = 6
+        self.write_col_headings(ws, AGREE_DISAGREE)
+
+        for sq_field, sq in SPECIAL_QUESTIONS.items():
+            counts = Counter()
+            for media_type, model in person_models.items():
+                sheet_name = model.sheet_name()
+                rows = model.objects \
+                        .values(sq_field, f"{sheet_name}__stereotypes", f"{sheet_name}__topic") \
+                        .filter(**{f"{sheet_name}__country__in": self.country_list}) \
+                        .exclude(**{sq_field: ""}) \
+                        .annotate(n=Count("id"))
+
+                rows= self.apply_weights(rows, model.sheet_db_table(), media_type)
+
+                counts.update({(r["stereotypes"], TOPIC_GROUPS[r['topic']]): r['n'] for r in rows})
+
+            self.write_primary_row_heading(ws, sq, r=r)
+            self.tabulate(ws, counts, AGREE_DISAGREE, MAJOR_TOPICS, row_perc=True, write_col_headings=False, r=r)
+            r += len(MAJOR_TOPICS)
 
     def ws_s01(self, ws):
         """

--- a/reports/report_details.py
+++ b/reports/report_details.py
@@ -1549,8 +1549,8 @@ WS_INFO = {
     'ws_107': {
         '2015': {
             'name': '107',
-            'title': 'Special questions, by medium, by major topic',
-            'desc': 'Special questions, by medium, by major topic',
+            'title': 'Special questions, by major topic, by medium',
+            'desc': '',
             'reports': ['country'],
         },
     },
@@ -1558,7 +1558,7 @@ WS_INFO = {
         '2015': {
             'name': '108',
             'title': 'Special questions, by major topic, by sex of source',
-            'desc': 'Special questions, by major topic, by sex of source',
+            'desc': '',
             'reports': ['country'],
         },
     },
@@ -1566,7 +1566,7 @@ WS_INFO = {
         '2015': {
             'name': '109',
             'title': 'Special questions, by major topic, by reporter',
-            'desc': 'Special questions, by major topic, by reporter',
+            'desc': '',
             'reports': ['country'],
         },
     },
@@ -1574,7 +1574,7 @@ WS_INFO = {
         '2015': {
             'name': '110',
             'title': 'Special questions, by major topic, by rights/policy',
-            'desc': 'Special questions, by major topic, by rights/policy',
+            'desc': '',
             'reports': ['country'],
         },
     },
@@ -1582,7 +1582,7 @@ WS_INFO = {
         '2015': {
             'name': '111',
             'title': 'Special questions, by major topic, by gender stereotypes',
-            'desc': 'Special questions, by major topic, by gender stereotypes',
+            'desc': '',
             'reports': ['country'],
         },
     },
@@ -2291,3 +2291,9 @@ REPORTER_MEDIA = [
     'Radio',
     'Television'
 ]
+
+SPECIAL_QUESTIONS = OrderedDict([
+    ("special_qn_1", "Special Question 1"),
+    ("special_qn_2", "Special Question 2"),
+    ("special_qn_3", "Special Question 3"),
+])


### PR DESCRIPTION
## Description

This PR implements the new special questions queries:

 - [x] `107`: **Special questions, by major topic, by medium**,
 - [x] `108`: **Special questions, by major topic, by sex of source**,
 - [x] `109`: **Special questions, by major topic, by reporter**,
 - [x] `110`: **Special questions, by major topic, by rights/policy**, and
 - [x] `111`: **Special questions, by major topic, by gender stereotypes**.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

### Antigua and Barbuda

![S](https://user-images.githubusercontent.com/1779590/110347259-79d27f80-8041-11eb-80ad-cf0ff8aae843.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
