### PR TITLE
[Feature] s Queries for Question (Z)

### DIFF
--- a/reports/report_builder.py
+++ b/reports/report_builder.py
@@ -4106,10 +4106,46 @@ class XLSXReportBuilder:
             c = ws.dim_colmax + 2
     
     def ws_s28(self, ws):
-        return
-    
+        """
+        Cols: Sex of subject
+        Rows: Country
+        """
+        counts = Counter()
+        for _, model in person_models.items():
+            sheet_name = model.sheet_name()
+            country_field = f"{sheet_name}__country"
+            rows = model.objects \
+                    .values('sex', country_field) \
+                    .filter(**{f"{sheet_name}__covid19": 1}) \
+                    .filter(**{f"{country_field}__in": self.country_list}) \
+                    .filter(sex__in=self.male_female_ids) \
+                    .annotate(n=Count('id'))
+
+            for row in rows:
+                counts.update({(row['sex'], self.recode_country(row[country_field])): row['n']})
+
+        self.tabulate(ws, counts, self.male_female, self.countries, row_perc=True, show_N=True)
+
     def ws_s29(self, ws):
-        return
+        """
+        Cols: Sex of reporter
+        Rows: Country
+        """
+        counts = Counter()
+        for _, model in journalist_models.items():
+            sheet_name = model.sheet_name()
+            country_field = f"{sheet_name}__country"
+            rows = model.objects \
+                    .values('sex', country_field) \
+                    .filter(**{f"{sheet_name}__covid19": 1}) \
+                    .filter(**{f"{country_field}__in": self.country_list}) \
+                    .filter(sex__in=self.male_female_ids) \
+                    .annotate(n=Count('id'))
+
+            for row in rows:
+                counts.update({(row['sex'], self.recode_country(row[country_field])): row['n']})
+
+        self.tabulate(ws, counts, self.male_female, self.countries, row_perc=True, show_N=True)
 
     def ws_sr01(self, ws):
         """


### PR DESCRIPTION
## Description

Implements the two new `s` queries related to `Question (Z)`:

  - [x] `s28`: **Response to Question (z) is this story related to Covid & response to sex of person in the news**, and
  - [x] `s29`: **Response to Question (z) is this story related to Covid & response to sex of reporter**.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![S](https://user-images.githubusercontent.com/1779590/110429237-aaef9600-80bb-11eb-82e3-e1526ea722e0.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
